### PR TITLE
feature/use_per_operation_sampler_first

### DIFF
--- a/samplers/jaegerremote/internal/utils/rate_limiter.go
+++ b/samplers/jaegerremote/internal/utils/rate_limiter.go
@@ -17,6 +17,7 @@
 package utils // import "go.opentelemetry.io/contrib/samplers/jaegerremote/internal/utils"
 
 import (
+	"math"
 	"sync"
 	"time"
 )
@@ -52,7 +53,7 @@ type RateLimiter struct {
 func NewRateLimiter(creditsPerSecond, maxBalance float64) *RateLimiter {
 	return &RateLimiter{
 		creditsPerSecond: creditsPerSecond,
-		balance:          maxBalance,
+		balance:          math.Min(creditsPerSecond, maxBalance),
 		maxBalance:       maxBalance,
 		lastTick:         time.Now(),
 		timeNow:          time.Now,

--- a/samplers/jaegerremote/sampler_remote_options.go
+++ b/samplers/jaegerremote/sampler_remote_options.go
@@ -52,12 +52,10 @@ func newConfig(options ...Option) config {
 	for _, option := range options {
 		option.apply(&c)
 	}
-	c.updaters = append(c.updaters,
-		&perOperationSamplerUpdater{
-			MaxOperations:            c.posParams.MaxOperations,
-			OperationNameLateBinding: c.posParams.OperationNameLateBinding,
-		})
-
+	c.updaters = append([]samplerUpdater{&perOperationSamplerUpdater{
+		MaxOperations:            c.posParams.MaxOperations,
+		OperationNameLateBinding: c.posParams.OperationNameLateBinding,
+	}}, c.updaters...)
 	return c
 }
 


### PR DESCRIPTION
1. set perOperationSamplerUpdater at head or sampler.updater, because we should use perOperationSampler when it's not empty

2. ratelimiter maxBlanace should be 0